### PR TITLE
enables far steps

### DIFF
--- a/service/battle_service.go
+++ b/service/battle_service.go
@@ -48,8 +48,10 @@ func SendBattlefield(position int, clanEmoji string, callbackQuery *telegram.Cal
 			var btn telegram.InlineKeyboardButton
 			if j == position {
 				btn = telegram.NewInlineKeyboardButtonData(clanEmoji, "PRESS_"+strconv.Itoa(j))
+			} else if IsAvailable(j, position) {
+				btn = telegram.NewInlineKeyboardButtonData(unknownTerritory+"ok", "PRESS_"+strconv.Itoa(j))
 			} else {
-				btn = telegram.NewInlineKeyboardButtonData(unknownTerritory, "PRESS_"+strconv.Itoa(j))
+				btn = telegram.NewInlineKeyboardButtonData(unknownTerritory, "PRESS_UNAVAILABLE")
 			}
 			row = append(row, btn)
 		}
@@ -85,4 +87,32 @@ func ClanParameters(callbackQuery *telegram.CallbackQuery) (string, int) {
 	}
 
 	return emoji, startPosition
+}
+
+func IsAvailable(j int, position int) bool {
+	res := false
+	for _, element := range AvailableTerritory(position) {
+		if j == element {
+			res = true
+			break
+		}
+	}
+	return res
+}
+
+func AvailableTerritory(position int) []int {
+	var availableTerritory []int
+	if !(position%5 == 1) {
+		availableTerritory = append(availableTerritory, position-1)
+		availableTerritory = append(availableTerritory, position+4)
+		availableTerritory = append(availableTerritory, position-6)
+	}
+	if !(position%5 == 0) {
+		availableTerritory = append(availableTerritory, position+1)
+		availableTerritory = append(availableTerritory, position+6)
+		availableTerritory = append(availableTerritory, position-4)
+	}
+	availableTerritory = append(availableTerritory, position+5)
+	availableTerritory = append(availableTerritory, position-5)
+	return availableTerritory
 }


### PR DESCRIPTION
Тепер ходити можна лише на сусідні клітинки. При натисканні на дальню все просто висить, бо я не зміг надіслати повідомлення. Я прописав функцію доступних клітинок, для них зберіг попередній алгоритм. Для усіх інших CallBackQuery вертає не PRESS_*NUMBER*, а PRESS_UNAVAILABLE, через що виникає помилка при переводі запиту в число  в message_service. Ще треба дописати дещо, але вже фуричить